### PR TITLE
Crockford jslint as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/v8"]
 	path = lib/v8
 	url = git://github.com/v8/v8.git
+[submodule "lib/jslint"]
+	path = lib/jslint
+	url = git://github.com/douglascrockford/JSLint.git

--- a/src/jslint.cpp
+++ b/src/jslint.cpp
@@ -55,7 +55,7 @@ Handle<String> load_source_js (char* src_file) {
     std::ifstream myfile (src_file);
     if (myfile.is_open()) {
         //std::cout << jslint::native_fulljslint << std::endl;
-        result = std::string(jslint::native_jslint) + "\nvar file_to_lint = [];\n";
+        result = std::string(jslint::native_fulljslint) + "\nvar file_to_lint = [];\n";
         while (! myfile.eof() ) {
             std::getline (myfile, line);
             jsline =  "file_to_lint.push(\"" + jslint::find_and_replace(line,"\"", "\\\"") + "\");";

--- a/tools/jslint2c.py
+++ b/tools/jslint2c.py
@@ -20,7 +20,26 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import sys
+import os
 import js2c
 
+JSLINT_SOURCE = 'lib/jslint/fulljslint.js'
+JSLINT_C_OUTPUT = 'src/jslint.h'
+
+BASE_DIR = os.path.dirname(os.path.realpath(__file__)) + "/../"
+
 if __name__ == "__main__":
-    js2c.JS2C(["./src/jslint.js"], ["./src/jslint.h"])
+    if not os.path.exists(BASE_DIR + JSLINT_SOURCE):
+      if os.path.exists(BASE_DIR + JSLINT_C_OUTPUT):
+          print "WARNING: %s cannot be found. Try updating git submodules." % JSLINT_SOURCE
+          print "Using existing %s" % JSLINT_C_OUTPUT
+      else:
+          print "ERROR: %s cannot be found.\nHave you run `git submodule init; git submodule update`?" % JSLINT_SOURCE
+          sys.exit(1)
+    else:
+      if not os.path.exists(BASE_DIR + JSLINT_C_OUTPUT) or os.path.getmtime(BASE_DIR + JSLINT_SOURCE) > os.path.getmtime(BASE_DIR + JSLINT_C_OUTPUT):
+          print "Converting %s to %s..." % (os.path.basename(JSLINT_SOURCE), os.path.basename(JSLINT_C_OUTPUT))
+          js2c.JS2C(["./lib/jslint/fulljslint.js"], ["./src/jslint.h"])
+      else:
+          print "Already converted %s to %s" % (os.path.basename(JSLINT_SOURCE), os.path.basename(JSLINT_C_OUTPUT))


### PR DESCRIPTION
This branch adds git://github.com/douglascrockford/JSLint.git as a submodule of jslint. It changes the jslint2c.py tool to use the submodule as the source of jslint.js when creating jslint.h.

If merging this branch after jslint/tclap, there will be a merge conflict in jslint.cpp. The simple fix is to change line ~71 from:

```
result = std::string(jslint::native_jslint) + "\nvar file_to_lint = [];\n";
```

to:

```
result = std::string(jslint::native_fulljslint) + "\nvar file_to_lint = [];\n";
```
